### PR TITLE
feat(github): created codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @acmutd/portal-maintainers


### PR DESCRIPTION
If you don't want the "Portal Maintainers" team to auto-assign at PR, then just decline this PR.