### PR TITLE
feat(slack): Create a slack lambda function to handle messaging functions

### DIFF
--- a/apps/documentation/docs/api-reference/slack.md
+++ b/apps/documentation/docs/api-reference/slack.md
@@ -3,3 +3,12 @@ sidebar_position: 0
 ---
 
 # Slack
+The [Slack API](https://api.slack.com/docs) service provides numerous utilities to interact with the ACM Slack workspace via trigger functions and API calls. The API's messaging functionality will be utilized to send updates, automate certain actions and notifications, and maintain the `#shoutouts` channel.
+
+The primary method of communication will be *Incoming Webhooks*, which are one-way webhooks that allow a given payload to be posted to a specific Slack channel by means of an unique URL.
+## Incoming Webhooks
+[Incoming Webhooks](https://api.slack.com/messaging/webhooks) are a feature of the Slack API that allow a payload to be posted to a specific Slack channel by means of a unique URL.
+
+### Sending Messages to a specific channel
+[Incoming Webhooks can be generated programmatically](https://api.slack.com/messaging/webhooks#incoming_webhooks_programmatic) to post a request to a specific channel, and are classified by the `channel` and `channel_id parameters.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,10 @@
       "resolved": "services/sendgrid",
       "link": true
     },
+    "node_modules/@acmutd/slack": {
+      "resolved": "services/slack",
+      "link": true
+    },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz",
@@ -3617,9 +3621,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -4820,6 +4824,421 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/expect": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.0.2.tgz",
+      "integrity": "sha512-rxgWG/updGoQtHFw/duImu5gPN48+kHvhVjLJ0fFk2mYQ+3dp7/zLiNTjSQxc92Bq4VOk+b6ln0gSgKM4etOtQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^28.0.2",
+        "jest-snapshot": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.0.2.tgz",
+      "integrity": "sha512-YryfH2zN5c7M8eLtn9oTBRj1sfD+X4cHNXJnTejqCveOS33wADEZUxJ7de5++lRvByNpRpfAnc8zTK7yrUJqgA==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/@jest/transform": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.0.2.tgz",
+      "integrity": "sha512-PgvB/DEwVY+vJAGTRSFhdmorytx54aXKK1+VQIxVtdFVAe0mJ2fUIRWQuGimveEJWT4ELJImZAIYOgs8z2L0eg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^28.0.2",
+        "@jridgewell/trace-mapping": "^0.3.7",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.0.2",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/@jest/types": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+      "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/@types/yargs": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+      "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/expect/node_modules/diff-sequences": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz",
+      "integrity": "sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/expect": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-28.0.2.tgz",
+      "integrity": "sha512-X0qIuI/zKv98k34tM+uGeOgAC73lhs4vROF9MkPk94C1zujtwv4Cla8SxhWn0G1OwvG9gLLL7RjFBkwGVaZ83w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "jest-matcher-utils": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-util": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-diff": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.0.2.tgz",
+      "integrity": "sha512-33Rnf821Y54OAloav0PGNWHlbtEorXpjwchnToyyWbec10X74FOW7hGfvrXLGz7xOe2dz0uo9JVFAHHj/2B5pg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-haste-map": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
+      "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "jest-worker": "^28.0.2",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-matcher-utils": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.0.2.tgz",
+      "integrity": "sha512-SxtTiI2qLJHFtOz/bySStCnwCvISAuxQ/grS+74dfTy5AuJw3Sgj9TVUvskcnImTfpzLoMCDJseRaeRrVYbAOA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-message-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz",
+      "integrity": "sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^28.0.2",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-regex-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-snapshot": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.0.2.tgz",
+      "integrity": "sha512-Y+2red99KRYY5vxA3HIE1p7p2MxPZz5uwamly18DII/9m/D2QQKcYqETS+/DjDthOxpnJWFqqku7MDzdpnHkHg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^28.0.2",
+        "@jest/transform": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/babel__traverse": "^7.0.6",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^28.0.2",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "jest-haste-map": "^28.0.2",
+        "jest-matcher-utils": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^28.0.2",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+      "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-worker": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
+      "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/pretty-format": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+      "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/react-is": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+      "dev": true
+    },
+    "node_modules/@jest/expect/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/write-file-atomic": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
     "node_modules/@jest/fake-timers": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
@@ -5296,6 +5715,18 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+      "integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.23.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/@jest/source-map": {
@@ -5775,9 +6206,9 @@
       "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -7555,6 +7986,12 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.4.tgz",
+      "integrity": "sha512-0/WqSvpVbCBAV1yPeko7eAczKbs78dNVAaX14quVlwOb2wxfKuXCx91h4NrEfkYK9zEnyVSW4JVI/trP3iS+Qg==",
+      "dev": true
+    },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -8978,13 +9415,13 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+      "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/type-utils": "5.21.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -9143,13 +9580,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+      "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -9169,12 +9606,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+      "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -9185,11 +9622,11 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+      "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
       "dependencies": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -9210,9 +9647,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+      "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -9222,12 +9659,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+      "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -9262,14 +9699,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+      "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -9285,11 +9722,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+      "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.21.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -10393,9 +10830,9 @@
       "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "node_modules/aws-sdk": {
-      "version": "2.1115.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1115.0.tgz",
-      "integrity": "sha512-WuMPBkE2b0hGRcF4oYw9zhjG0PC20lFKHT5FS8PXgZgu4GK8adQ8oIK0wBYPjq3F6b+VNdhDWSy3R7a6K+ENOQ==",
+      "version": "2.1124.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1124.0.tgz",
+      "integrity": "sha512-LIj2EmvduQmyjpSLoDPe2TvRBrGWhJKlCuC7lungN4f+qYPOfVWg6/c9GdP99W0q5p2IqhDkCmQ/ZZBpO1Z/Fg==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -15888,11 +16325,11 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
-      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.1",
+        "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -22996,26 +23433,23 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "27.2.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.2.tgz",
-      "integrity": "sha512-tfbHcBs/hJTb3fPQ/3hLWR+TsLNTzzK98TU+zIAsrL9nNzWfWROwopUOmiSUqmHMZW5t9au/433kSF2/Af+tTw==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.0.2.tgz",
+      "integrity": "sha512-4smZQ+Z4bzRNAXmj2HSrDYOAVar/SBDClUWxDJrz3BHbw+URXGAPenziWIShmybBlcRnX0lVCs43UiB7+Fh+lg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
-        "escalade": "^3.1.1",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.2.2",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.0.2",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.2.0",
-        "jest-validate": "^27.2.2",
+        "jest-util": "^28.0.2",
+        "jest-validate": "^28.0.2",
         "resolve": "^1.20.0",
+        "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/jest-resolve-dependencies": {
@@ -23032,13 +23466,37 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/jest-resolve/node_modules/@jest/types": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+      "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/@types/yargs": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+      "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
     "node_modules/jest-resolve/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -23054,8 +23512,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -23072,8 +23528,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -23085,28 +23539,161 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/jest-resolve/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jest-resolve/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/jest-haste-map": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
+      "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "jest-worker": "^28.0.2",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/jest-regex-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/jest-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+      "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/jest-validate": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.0.2.tgz",
+      "integrity": "sha512-nr0UOvCTtxP0YPdsk01Gk7e7c0xIiEe2nncAe3pj0wBfUvAykTVrMrdeASlAJnlEQCBuwN/GF4hKoCzbkGNCNw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^28.0.2",
+        "leven": "^3.1.0",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/jest-worker": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
+      "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/pretty-format": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+      "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/react-is": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+      "dev": true
     },
     "node_modules/jest-resolve/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -42833,6 +43420,40 @@
         "node": ">=8"
       }
     },
+    "services/slack": {
+      "name": "@acmutd/slack",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@middy/core": "^2.5.7",
+        "@middy/http-json-body-parser": "^2.5.7",
+        "@middy/sqs-json-body-parser": "^2.5.7",
+        "@middy/validator": "^2.5.7",
+        "aws-lambda": "^1.0.7",
+        "aws-sdk": "^2.1122.0",
+        "axios": "^0.27.1",
+        "middy-middleware-json-error-handler": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.17.9",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-typescript": "^7.16.7",
+        "@typescript-eslint/eslint-plugin": "^5.21.0",
+        "@typescript-eslint/parser": "^5.21.0",
+        "babel-jest": "^28.0.1",
+        "eslint": "^8.14.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-module-resolver": "^1.4.0",
+        "fork-ts-checker-webpack-plugin": "^7.2.7",
+        "jest": "^28.0.1",
+        "serverless-webpack": "^5.7.0",
+        "typescript-eslint": "^0.0.1-alpha.0",
+        "webpack-node-externals": "^3.0.0"
+      }
+    },
     "services/slack-messaging": {
       "version": "1.0.0",
       "extraneous": true,
@@ -42871,6 +43492,1161 @@
         "serverless-webpack": "^5.7.0",
         "typescript-eslint": "^0.0.1-alpha.0",
         "webpack-node-externals": "^3.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/console": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.0.2.tgz",
+      "integrity": "sha512-tiRpnMeeyQuuzgL5UNSeiqMwF8UOWPbAE5rzcu/1zyq4oPG2Ox6xm4YCOruwbp10F8odWc+XwVxTyGzMSLMqxA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/core": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.0.2.tgz",
+      "integrity": "sha512-AK6xU9wfo9E3wA4fY8t59I2t5hnS3eCVYhD1OVZPMZyUrtIQbU1HR+h9jz3ulsEv39xSDH94QY2IJr46O637ag==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^28.0.2",
+        "@jest/reporters": "^28.0.2",
+        "@jest/test-result": "^28.0.2",
+        "@jest/transform": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^28.0.2",
+        "jest-config": "^28.0.2",
+        "jest-haste-map": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.0.2",
+        "jest-resolve-dependencies": "^28.0.2",
+        "jest-runner": "^28.0.2",
+        "jest-runtime": "^28.0.2",
+        "jest-snapshot": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "jest-validate": "^28.0.2",
+        "jest-watcher": "^28.0.2",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.0.2",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "services/slack/node_modules/@jest/environment": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.0.2.tgz",
+      "integrity": "sha512-IvI7dEfqVEffDYlw9FQfVBt6kXt/OI38V7QUIur0ulOQgzpKYJDVvLzj4B1TVmHWTGW5tcnJdlZ3hqzV6/I9Qg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "jest-mock": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/fake-timers": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.0.2.tgz",
+      "integrity": "sha512-R75yUv+WeybPa4ZVhX9C+8XN0TKjUoceUX+/QEaDVQGxZZOK50eD74cs7iMDTtpodh00d8iLlc9197vgF6oZjA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@sinonjs/fake-timers": "^9.1.1",
+        "@types/node": "*",
+        "jest-message-util": "^28.0.2",
+        "jest-mock": "^28.0.2",
+        "jest-util": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/globals": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.0.2.tgz",
+      "integrity": "sha512-gkOd1rTTLoZGM2OqOtf5wyzf8HNoM2a+dGbyWgqO3spQiA/OBE+d1kQlZ6mYs9NtJwJ1/TNAJNyBaPXIeo7xEw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.0.2",
+        "@jest/expect": "^28.0.2",
+        "@jest/types": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/reporters": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-28.0.2.tgz",
+      "integrity": "sha512-YOxPWwVwgY2u6h6XOnOILZVZFUthIr86ttvXrdRg8VC/8fg2Vwk4d/fxY6uLDCFE/3CFthXTsVB05kmBjckCsw==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^28.0.2",
+        "@jest/test-result": "^28.0.2",
+        "@jest/transform": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@jridgewell/trace-mapping": "^0.3.7",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-util": "^28.0.2",
+        "jest-worker": "^28.0.2",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "services/slack/node_modules/@jest/source-map": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-28.0.2.tgz",
+      "integrity": "sha512-Y9dxC8ZpN3kImkk0LkK5XCEneYMAXlZ8m5bflmSL5vrwyeUpJfentacCUg6fOb8NOpOO7hz2+l37MV77T6BFPw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.7",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/test-result": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.0.2.tgz",
+      "integrity": "sha512-4EUqgjq9VzyUiVTvZfI9IRJD6t3NYBNP4f+Eq8Zr93+hkJ0RrGU4OBTw8tfNzidKX+bmuYzn8FxqpxOPIGGCMA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/test-sequencer": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.0.2.tgz",
+      "integrity": "sha512-zhnZ8ydkZQTPL7YucB86eOlD79zPy5EGSUKiR2Iv93RVEDU6OEP33kwDBg70ywOcxeJGDRhyo09q7TafNCBiIg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^28.0.2",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/transform": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.0.2.tgz",
+      "integrity": "sha512-PgvB/DEwVY+vJAGTRSFhdmorytx54aXKK1+VQIxVtdFVAe0mJ2fUIRWQuGimveEJWT4ELJImZAIYOgs8z2L0eg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^28.0.2",
+        "@jridgewell/trace-mapping": "^0.3.7",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.0.2",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@jest/types": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+      "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "services/slack/node_modules/@types/yargs": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+      "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "services/slack/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "services/slack/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "services/slack/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "services/slack/node_modules/babel-jest": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.0.2.tgz",
+      "integrity": "sha512-OlbfoOpHmU3jzAWoiT98bBuAhjrSZMxSVk5ALkCL/8ocb8dyx8F4H9NlBjH2xd08MI5306Yxa0+y87cjY55Eqw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^28.0.2",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^28.0.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "services/slack/node_modules/babel-plugin-jest-hoist": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.0.2.tgz",
+      "integrity": "sha512-Kizhn/ZL+68ZQHxSnHyuvJv8IchXD62KQxV77TBDV/xoBFBOfgRAk97GNs6hXdTTCiVES9nB2I6+7MXXrk5llQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/babel-preset-jest": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.0.2.tgz",
+      "integrity": "sha512-sYzXIdgIXXroJTFeB3S6sNDWtlJ2dllCdTEsnZ65ACrMojj3hVNFRmnJ1HZtomGi+Be7aqpY/HJ92fr8OhKVkQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^28.0.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "services/slack/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "services/slack/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "services/slack/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "services/slack/node_modules/diff-sequences": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz",
+      "integrity": "sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/emittery": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+      "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "services/slack/node_modules/eslint-import-resolver-typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
+      "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "glob": "^7.2.0",
+        "is-glob": "^4.0.3",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
+    "services/slack/node_modules/expect": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-28.0.2.tgz",
+      "integrity": "sha512-X0qIuI/zKv98k34tM+uGeOgAC73lhs4vROF9MkPk94C1zujtwv4Cla8SxhWn0G1OwvG9gLLL7RjFBkwGVaZ83w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "jest-matcher-utils": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-util": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/fork-ts-checker-webpack-plugin": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.8.tgz",
+      "integrity": "sha512-kvOM0w3Hi66o3qNLWNN9mWcMXwZNjuQ0+LMloxAM+QL5ZRGV6sLZnFyM86qKLNWklEG5XofcYWSAVosjtNg+vg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "cosmiconfig": "^7.0.1",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^10.0.0",
+        "memfs": "^3.4.1",
+        "minimatch": "^3.0.4",
+        "schema-utils": "^3.1.1",
+        "semver": "^7.3.5",
+        "tapable": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=12.13.0",
+        "yarn": ">=1.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">3.6.0",
+        "vue-template-compiler": "*",
+        "webpack": "^5.11.0"
+      },
+      "peerDependenciesMeta": {
+        "vue-template-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "services/slack/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "services/slack/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "services/slack/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "services/slack/node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "services/slack/node_modules/jest": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-28.0.2.tgz",
+      "integrity": "sha512-COUtjybolW4koQvO7kCfq5kgbeeU5WbSJfVZprz4zbS8AL32+RAZZTUjBEyRRdpsXqss/pHIvSL7/P+LyMYHXg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^28.0.2",
+        "import-local": "^3.0.2",
+        "jest-cli": "^28.0.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "services/slack/node_modules/jest-changed-files": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.0.2.tgz",
+      "integrity": "sha512-QX9u+5I2s54ZnGoMEjiM2WeBvJR2J7w/8ZUmH2um/WLAuGAYFQcsVXY9+1YL6k0H/AGUdH8pXUAv6erDqEsvIA==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-circus": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.0.2.tgz",
+      "integrity": "sha512-5U0K43UZSwu9xBo3RmK366Y8i0YMTGe2hgFm7TYka6ecT5lB0VZ+/TQTTsDVxa9q1TuOWRa7EskSMm1Q74Hy/Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.0.2",
+        "@jest/expect": "^28.0.2",
+        "@jest/test-result": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^28.0.2",
+        "jest-matcher-utils": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-runtime": "^28.0.2",
+        "jest-snapshot": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "pretty-format": "^28.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-cli": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.0.2.tgz",
+      "integrity": "sha512-X6KSoKiSDZ07lds9awDMd14VUmtLS0sxgbUzZi1m6JewWdwXtuadTBff1kAUcAmKgJTYBPnVN0u2BKp7AIzllA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^28.0.2",
+        "@jest/test-result": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "import-local": "^3.0.2",
+        "jest-config": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "jest-validate": "^28.0.2",
+        "prompts": "^2.0.1",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "services/slack/node_modules/jest-config": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.0.2.tgz",
+      "integrity": "sha512-4E5r24Dw1DsyF4ObkwiDEqXIwrX7p01mnngWKtB/0Jdb0SpR1UGAm8Bjg6GTozCA4SlSj/Bbq7LTkg0WrzLanQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "babel-jest": "^28.0.2",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^28.0.2",
+        "jest-environment-node": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.0.2",
+        "jest-runner": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "jest-validate": "^28.0.2",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^28.0.2",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "services/slack/node_modules/jest-diff": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.0.2.tgz",
+      "integrity": "sha512-33Rnf821Y54OAloav0PGNWHlbtEorXpjwchnToyyWbec10X74FOW7hGfvrXLGz7xOe2dz0uo9JVFAHHj/2B5pg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-docblock": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.0.2.tgz",
+      "integrity": "sha512-FH10WWw5NxLoeSdQlJwu+MTiv60aXV/t8KEwIRGEv74WARE1cXIqh1vGdy2CraHuWOOrnzTWj/azQKqW4fO7xg==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-each": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.0.2.tgz",
+      "integrity": "sha512-/W5Wc0b+ipR36kDaLngdVEJ/5UYPOITK7rW0djTlCCQdMuWpCFJweMW4TzAoJ6GiRrljPL8FwiyOSoSHKrda2w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-environment-node": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.0.2.tgz",
+      "integrity": "sha512-o9u5UHZ+NCuIoa44KEF0Behhsz/p1wMm0WumsZfWR1k4IVoWSt3aN0BavSC5dd26VxSGQvkrCnJxxOzhhUEG3Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.0.2",
+        "@jest/fake-timers": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "jest-mock": "^28.0.2",
+        "jest-util": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-haste-map": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
+      "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "jest-worker": "^28.0.2",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "services/slack/node_modules/jest-leak-detector": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.0.2.tgz",
+      "integrity": "sha512-UGaSPYtxKXl/YKacq6juRAKmMp1z2os8NaU8PSC+xvNikmu3wF6QFrXrihMM4hXeMr9HuNotBrQZHmzDY8KIBQ==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-matcher-utils": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.0.2.tgz",
+      "integrity": "sha512-SxtTiI2qLJHFtOz/bySStCnwCvISAuxQ/grS+74dfTy5AuJw3Sgj9TVUvskcnImTfpzLoMCDJseRaeRrVYbAOA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-message-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz",
+      "integrity": "sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^28.0.2",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-mock": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-28.0.2.tgz",
+      "integrity": "sha512-vfnJ4zXRB0i24jOTGtQJyl26JKsgBKtqRlCnsrORZbG06FToSSn33h2x/bmE8XxqxkLWdZBRo+/65l8Vi3nD+g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-regex-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-resolve-dependencies": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.0.2.tgz",
+      "integrity": "sha512-Xgkc51baZJQ9UcZg8UN9rGtnvqoVHeDNP6iM4QV3W/phzbFyRCiAxqgJ2GyuBnzGm2EirUlIcstlvOR/6trHmw==",
+      "dev": true,
+      "dependencies": {
+        "jest-regex-util": "^28.0.2",
+        "jest-snapshot": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-runner": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.0.2.tgz",
+      "integrity": "sha512-biaiCtgNAeTl1GrHezlWLbTStoi/aP4X2FOZaAhdbHUAflUg4bal6q3Ck8VNhTGzkXVeFtVVZFHE5PHlyUAJBw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^28.0.2",
+        "@jest/environment": "^28.0.2",
+        "@jest/test-result": "^28.0.2",
+        "@jest/transform": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.10.2",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^28.0.2",
+        "jest-environment-node": "^28.0.2",
+        "jest-haste-map": "^28.0.2",
+        "jest-leak-detector": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-resolve": "^28.0.2",
+        "jest-runtime": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "jest-watcher": "^28.0.2",
+        "jest-worker": "^28.0.2",
+        "source-map-support": "0.5.13",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-runtime": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.0.2.tgz",
+      "integrity": "sha512-fUoJ/GVrCj7pdYYXfET8bBudDmefmnscd/0jBkBAgHTs3qu+rGXUAV3QN/ECNhWhhEXoJ5a2PnSFTJ8RmXM6xQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.0.2",
+        "@jest/fake-timers": "^28.0.2",
+        "@jest/globals": "^28.0.2",
+        "@jest/source-map": "^28.0.2",
+        "@jest/test-result": "^28.0.2",
+        "@jest/transform": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-mock": "^28.0.2",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.0.2",
+        "jest-snapshot": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-snapshot": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.0.2.tgz",
+      "integrity": "sha512-Y+2red99KRYY5vxA3HIE1p7p2MxPZz5uwamly18DII/9m/D2QQKcYqETS+/DjDthOxpnJWFqqku7MDzdpnHkHg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^28.0.2",
+        "@jest/transform": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/babel__traverse": "^7.0.6",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^28.0.2",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^28.0.2",
+        "jest-get-type": "^28.0.2",
+        "jest-haste-map": "^28.0.2",
+        "jest-matcher-utils": "^28.0.2",
+        "jest-message-util": "^28.0.2",
+        "jest-util": "^28.0.2",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^28.0.2",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+      "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-validate": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.0.2.tgz",
+      "integrity": "sha512-nr0UOvCTtxP0YPdsk01Gk7e7c0xIiEe2nncAe3pj0wBfUvAykTVrMrdeASlAJnlEQCBuwN/GF4hKoCzbkGNCNw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.0.2",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^28.0.2",
+        "leven": "^3.1.0",
+        "pretty-format": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-watcher": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.0.2.tgz",
+      "integrity": "sha512-uIVJLpQ/5VTGQWBiBatHsi7jrCqHjHl0e0dFHMWzwuIfUbdW/muk0DtSr0fteY2T7QTFylv+7a5Rm8sBKrE12Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^28.0.2",
+        "@jest/types": "^28.0.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.10.2",
+        "jest-util": "^28.0.2",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-worker": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
+      "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "services/slack/node_modules/pretty-format": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+      "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "services/slack/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "services/slack/node_modules/react-is": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+      "dev": true
+    },
+    "services/slack/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "services/slack/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "services/slack/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "services/slack/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "services/slack/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "services/slack/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "services/slack/node_modules/v8-to-istanbul": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.0.tgz",
+      "integrity": "sha512-HcvgY/xaRm7isYmyx+lFKA4uQmfUbN0J4M0nNItvzTvH/iQ9kW5j/t4YSR+Ge323/lrgDAWJoF46tzGQHwBHFw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.7",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "services/slack/node_modules/write-file-atomic": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     }
   },
@@ -46040,6 +47816,916 @@
         }
       }
     },
+    "@acmutd/slack": {
+      "version": "file:services/slack",
+      "requires": {
+        "@babel/core": "^7.17.9",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-typescript": "^7.16.7",
+        "@middy/core": "^2.5.7",
+        "@middy/http-json-body-parser": "^2.5.7",
+        "@middy/sqs-json-body-parser": "^2.5.7",
+        "@middy/validator": "^2.5.7",
+        "@typescript-eslint/eslint-plugin": "^5.21.0",
+        "@typescript-eslint/parser": "^5.21.0",
+        "aws-lambda": "^1.0.7",
+        "aws-sdk": "^2.1122.0",
+        "axios": "^0.27.1",
+        "babel-jest": "^28.0.1",
+        "eslint": "^8.14.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-module-resolver": "^1.4.0",
+        "fork-ts-checker-webpack-plugin": "^7.2.7",
+        "jest": "^28.0.1",
+        "middy-middleware-json-error-handler": "^3.0.0",
+        "serverless-webpack": "^5.7.0",
+        "typescript-eslint": "^0.0.1-alpha.0",
+        "webpack-node-externals": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.0.2.tgz",
+          "integrity": "sha512-tiRpnMeeyQuuzgL5UNSeiqMwF8UOWPbAE5rzcu/1zyq4oPG2Ox6xm4YCOruwbp10F8odWc+XwVxTyGzMSLMqxA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.0.2.tgz",
+          "integrity": "sha512-AK6xU9wfo9E3wA4fY8t59I2t5hnS3eCVYhD1OVZPMZyUrtIQbU1HR+h9jz3ulsEv39xSDH94QY2IJr46O637ag==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^28.0.2",
+            "@jest/reporters": "^28.0.2",
+            "@jest/test-result": "^28.0.2",
+            "@jest/transform": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.9",
+            "jest-changed-files": "^28.0.2",
+            "jest-config": "^28.0.2",
+            "jest-haste-map": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-regex-util": "^28.0.2",
+            "jest-resolve": "^28.0.2",
+            "jest-resolve-dependencies": "^28.0.2",
+            "jest-runner": "^28.0.2",
+            "jest-runtime": "^28.0.2",
+            "jest-snapshot": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "jest-validate": "^28.0.2",
+            "jest-watcher": "^28.0.2",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^28.0.2",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.0.2.tgz",
+          "integrity": "sha512-IvI7dEfqVEffDYlw9FQfVBt6kXt/OI38V7QUIur0ulOQgzpKYJDVvLzj4B1TVmHWTGW5tcnJdlZ3hqzV6/I9Qg==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "jest-mock": "^28.0.2"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.0.2.tgz",
+          "integrity": "sha512-R75yUv+WeybPa4ZVhX9C+8XN0TKjUoceUX+/QEaDVQGxZZOK50eD74cs7iMDTtpodh00d8iLlc9197vgF6oZjA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@sinonjs/fake-timers": "^9.1.1",
+            "@types/node": "*",
+            "jest-message-util": "^28.0.2",
+            "jest-mock": "^28.0.2",
+            "jest-util": "^28.0.2"
+          }
+        },
+        "@jest/globals": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.0.2.tgz",
+          "integrity": "sha512-gkOd1rTTLoZGM2OqOtf5wyzf8HNoM2a+dGbyWgqO3spQiA/OBE+d1kQlZ6mYs9NtJwJ1/TNAJNyBaPXIeo7xEw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.0.2",
+            "@jest/expect": "^28.0.2",
+            "@jest/types": "^28.0.2"
+          }
+        },
+        "@jest/reporters": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-28.0.2.tgz",
+          "integrity": "sha512-YOxPWwVwgY2u6h6XOnOILZVZFUthIr86ttvXrdRg8VC/8fg2Vwk4d/fxY6uLDCFE/3CFthXTsVB05kmBjckCsw==",
+          "dev": true,
+          "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^28.0.2",
+            "@jest/test-result": "^28.0.2",
+            "@jest/transform": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@jridgewell/trace-mapping": "^0.3.7",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^5.1.0",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.1.3",
+            "jest-util": "^28.0.2",
+            "jest-worker": "^28.0.2",
+            "slash": "^3.0.0",
+            "string-length": "^4.0.1",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^9.0.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-28.0.2.tgz",
+          "integrity": "sha512-Y9dxC8ZpN3kImkk0LkK5XCEneYMAXlZ8m5bflmSL5vrwyeUpJfentacCUg6fOb8NOpOO7hz2+l37MV77T6BFPw==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/trace-mapping": "^0.3.7",
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.9"
+          }
+        },
+        "@jest/test-result": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.0.2.tgz",
+          "integrity": "sha512-4EUqgjq9VzyUiVTvZfI9IRJD6t3NYBNP4f+Eq8Zr93+hkJ0RrGU4OBTw8tfNzidKX+bmuYzn8FxqpxOPIGGCMA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.0.2.tgz",
+          "integrity": "sha512-zhnZ8ydkZQTPL7YucB86eOlD79zPy5EGSUKiR2Iv93RVEDU6OEP33kwDBg70ywOcxeJGDRhyo09q7TafNCBiIg==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^28.0.2",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.0.2",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.0.2.tgz",
+          "integrity": "sha512-PgvB/DEwVY+vJAGTRSFhdmorytx54aXKK1+VQIxVtdFVAe0mJ2fUIRWQuGimveEJWT4ELJImZAIYOgs8z2L0eg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/types": "^28.0.2",
+            "@jridgewell/trace-mapping": "^0.3.7",
+            "babel-plugin-istanbul": "^6.1.1",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.0.2",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "micromatch": "^4.0.4",
+            "pirates": "^4.0.4",
+            "slash": "^3.0.0",
+            "write-file-atomic": "^4.0.1"
+          }
+        },
+        "@jest/types": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+          "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+          "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.10",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+          "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "babel-jest": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.0.2.tgz",
+          "integrity": "sha512-OlbfoOpHmU3jzAWoiT98bBuAhjrSZMxSVk5ALkCL/8ocb8dyx8F4H9NlBjH2xd08MI5306Yxa0+y87cjY55Eqw==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^28.0.2",
+            "@types/babel__core": "^7.1.14",
+            "babel-plugin-istanbul": "^6.1.1",
+            "babel-preset-jest": "^28.0.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "slash": "^3.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.0.2.tgz",
+          "integrity": "sha512-Kizhn/ZL+68ZQHxSnHyuvJv8IchXD62KQxV77TBDV/xoBFBOfgRAk97GNs6hXdTTCiVES9nB2I6+7MXXrk5llQ==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.3.3",
+            "@babel/types": "^7.3.3",
+            "@types/babel__core": "^7.1.14",
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.0.2.tgz",
+          "integrity": "sha512-sYzXIdgIXXroJTFeB3S6sNDWtlJ2dllCdTEsnZ65ACrMojj3hVNFRmnJ1HZtomGi+Be7aqpY/HJ92fr8OhKVkQ==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^28.0.2",
+            "babel-preset-current-node-syntax": "^1.0.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz",
+          "integrity": "sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==",
+          "dev": true
+        },
+        "emittery": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+          "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
+          "dev": true
+        },
+        "eslint-import-resolver-typescript": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
+          "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4",
+            "glob": "^7.2.0",
+            "is-glob": "^4.0.3",
+            "resolve": "^1.22.0",
+            "tsconfig-paths": "^3.14.1"
+          }
+        },
+        "expect": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-28.0.2.tgz",
+          "integrity": "sha512-X0qIuI/zKv98k34tM+uGeOgAC73lhs4vROF9MkPk94C1zujtwv4Cla8SxhWn0G1OwvG9gLLL7RjFBkwGVaZ83w==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "jest-matcher-utils": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-util": "^28.0.2"
+          }
+        },
+        "fork-ts-checker-webpack-plugin": {
+          "version": "7.2.8",
+          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.8.tgz",
+          "integrity": "sha512-kvOM0w3Hi66o3qNLWNN9mWcMXwZNjuQ0+LMloxAM+QL5ZRGV6sLZnFyM86qKLNWklEG5XofcYWSAVosjtNg+vg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.7",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "cosmiconfig": "^7.0.1",
+            "deepmerge": "^4.2.2",
+            "fs-extra": "^10.0.0",
+            "memfs": "^3.4.1",
+            "minimatch": "^3.0.4",
+            "schema-utils": "^3.1.1",
+            "semver": "^7.3.5",
+            "tapable": "^2.2.1"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+          "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.14.7",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.2.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "jest": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-28.0.2.tgz",
+          "integrity": "sha512-COUtjybolW4koQvO7kCfq5kgbeeU5WbSJfVZprz4zbS8AL32+RAZZTUjBEyRRdpsXqss/pHIvSL7/P+LyMYHXg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^28.0.2",
+            "import-local": "^3.0.2",
+            "jest-cli": "^28.0.2"
+          }
+        },
+        "jest-changed-files": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.0.2.tgz",
+          "integrity": "sha512-QX9u+5I2s54ZnGoMEjiM2WeBvJR2J7w/8ZUmH2um/WLAuGAYFQcsVXY9+1YL6k0H/AGUdH8pXUAv6erDqEsvIA==",
+          "dev": true,
+          "requires": {
+            "execa": "^5.0.0",
+            "throat": "^6.0.1"
+          }
+        },
+        "jest-circus": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.0.2.tgz",
+          "integrity": "sha512-5U0K43UZSwu9xBo3RmK366Y8i0YMTGe2hgFm7TYka6ecT5lB0VZ+/TQTTsDVxa9q1TuOWRa7EskSMm1Q74Hy/Q==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.0.2",
+            "@jest/expect": "^28.0.2",
+            "@jest/test-result": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "dedent": "^0.7.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^28.0.2",
+            "jest-matcher-utils": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-runtime": "^28.0.2",
+            "jest-snapshot": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "pretty-format": "^28.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3",
+            "throat": "^6.0.1"
+          }
+        },
+        "jest-cli": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.0.2.tgz",
+          "integrity": "sha512-X6KSoKiSDZ07lds9awDMd14VUmtLS0sxgbUzZi1m6JewWdwXtuadTBff1kAUcAmKgJTYBPnVN0u2BKp7AIzllA==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^28.0.2",
+            "@jest/test-result": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.9",
+            "import-local": "^3.0.2",
+            "jest-config": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "jest-validate": "^28.0.2",
+            "prompts": "^2.0.1",
+            "yargs": "^17.3.1"
+          }
+        },
+        "jest-config": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.0.2.tgz",
+          "integrity": "sha512-4E5r24Dw1DsyF4ObkwiDEqXIwrX7p01mnngWKtB/0Jdb0SpR1UGAm8Bjg6GTozCA4SlSj/Bbq7LTkg0WrzLanQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/test-sequencer": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "babel-jest": "^28.0.2",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-circus": "^28.0.2",
+            "jest-environment-node": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "jest-regex-util": "^28.0.2",
+            "jest-resolve": "^28.0.2",
+            "jest-runner": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "jest-validate": "^28.0.2",
+            "micromatch": "^4.0.4",
+            "parse-json": "^5.2.0",
+            "pretty-format": "^28.0.2",
+            "slash": "^3.0.0",
+            "strip-json-comments": "^3.1.1"
+          }
+        },
+        "jest-diff": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.0.2.tgz",
+          "integrity": "sha512-33Rnf821Y54OAloav0PGNWHlbtEorXpjwchnToyyWbec10X74FOW7hGfvrXLGz7xOe2dz0uo9JVFAHHj/2B5pg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-docblock": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.0.2.tgz",
+          "integrity": "sha512-FH10WWw5NxLoeSdQlJwu+MTiv60aXV/t8KEwIRGEv74WARE1cXIqh1vGdy2CraHuWOOrnzTWj/azQKqW4fO7xg==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "^3.0.0"
+          }
+        },
+        "jest-each": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.0.2.tgz",
+          "integrity": "sha512-/W5Wc0b+ipR36kDaLngdVEJ/5UYPOITK7rW0djTlCCQdMuWpCFJweMW4TzAoJ6GiRrljPL8FwiyOSoSHKrda2w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-environment-node": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.0.2.tgz",
+          "integrity": "sha512-o9u5UHZ+NCuIoa44KEF0Behhsz/p1wMm0WumsZfWR1k4IVoWSt3aN0BavSC5dd26VxSGQvkrCnJxxOzhhUEG3Q==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.0.2",
+            "@jest/fake-timers": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "jest-mock": "^28.0.2",
+            "jest-util": "^28.0.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
+          "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.3.2",
+            "graceful-fs": "^4.2.9",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "jest-worker": "^28.0.2",
+            "micromatch": "^4.0.4",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.0.2.tgz",
+          "integrity": "sha512-UGaSPYtxKXl/YKacq6juRAKmMp1z2os8NaU8PSC+xvNikmu3wF6QFrXrihMM4hXeMr9HuNotBrQZHmzDY8KIBQ==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.0.2.tgz",
+          "integrity": "sha512-SxtTiI2qLJHFtOz/bySStCnwCvISAuxQ/grS+74dfTy5AuJw3Sgj9TVUvskcnImTfpzLoMCDJseRaeRrVYbAOA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-message-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz",
+          "integrity": "sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^28.0.2",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^28.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-mock": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-28.0.2.tgz",
+          "integrity": "sha512-vfnJ4zXRB0i24jOTGtQJyl26JKsgBKtqRlCnsrORZbG06FToSSn33h2x/bmE8XxqxkLWdZBRo+/65l8Vi3nD+g==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/node": "*"
+          }
+        },
+        "jest-regex-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+          "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+          "dev": true
+        },
+        "jest-resolve-dependencies": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.0.2.tgz",
+          "integrity": "sha512-Xgkc51baZJQ9UcZg8UN9rGtnvqoVHeDNP6iM4QV3W/phzbFyRCiAxqgJ2GyuBnzGm2EirUlIcstlvOR/6trHmw==",
+          "dev": true,
+          "requires": {
+            "jest-regex-util": "^28.0.2",
+            "jest-snapshot": "^28.0.2"
+          }
+        },
+        "jest-runner": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.0.2.tgz",
+          "integrity": "sha512-biaiCtgNAeTl1GrHezlWLbTStoi/aP4X2FOZaAhdbHUAflUg4bal6q3Ck8VNhTGzkXVeFtVVZFHE5PHlyUAJBw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^28.0.2",
+            "@jest/environment": "^28.0.2",
+            "@jest/test-result": "^28.0.2",
+            "@jest/transform": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "emittery": "^0.10.2",
+            "graceful-fs": "^4.2.9",
+            "jest-docblock": "^28.0.2",
+            "jest-environment-node": "^28.0.2",
+            "jest-haste-map": "^28.0.2",
+            "jest-leak-detector": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-resolve": "^28.0.2",
+            "jest-runtime": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "jest-watcher": "^28.0.2",
+            "jest-worker": "^28.0.2",
+            "source-map-support": "0.5.13",
+            "throat": "^6.0.1"
+          }
+        },
+        "jest-runtime": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.0.2.tgz",
+          "integrity": "sha512-fUoJ/GVrCj7pdYYXfET8bBudDmefmnscd/0jBkBAgHTs3qu+rGXUAV3QN/ECNhWhhEXoJ5a2PnSFTJ8RmXM6xQ==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.0.2",
+            "@jest/fake-timers": "^28.0.2",
+            "@jest/globals": "^28.0.2",
+            "@jest/source-map": "^28.0.2",
+            "@jest/test-result": "^28.0.2",
+            "@jest/transform": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "chalk": "^4.0.0",
+            "cjs-module-lexer": "^1.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "execa": "^5.0.0",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-mock": "^28.0.2",
+            "jest-regex-util": "^28.0.2",
+            "jest-resolve": "^28.0.2",
+            "jest-snapshot": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.0.2.tgz",
+          "integrity": "sha512-Y+2red99KRYY5vxA3HIE1p7p2MxPZz5uwamly18DII/9m/D2QQKcYqETS+/DjDthOxpnJWFqqku7MDzdpnHkHg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@babel/generator": "^7.7.2",
+            "@babel/plugin-syntax-typescript": "^7.7.2",
+            "@babel/traverse": "^7.7.2",
+            "@babel/types": "^7.3.3",
+            "@jest/expect-utils": "^28.0.2",
+            "@jest/transform": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/babel__traverse": "^7.0.6",
+            "@types/prettier": "^2.1.5",
+            "babel-preset-current-node-syntax": "^1.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^28.0.2",
+            "graceful-fs": "^4.2.9",
+            "jest-diff": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "jest-haste-map": "^28.0.2",
+            "jest-matcher-utils": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^28.0.2",
+            "semver": "^7.3.5"
+          }
+        },
+        "jest-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+          "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "jest-validate": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.0.2.tgz",
+          "integrity": "sha512-nr0UOvCTtxP0YPdsk01Gk7e7c0xIiEe2nncAe3pj0wBfUvAykTVrMrdeASlAJnlEQCBuwN/GF4hKoCzbkGNCNw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^28.0.2",
+            "leven": "^3.1.0",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-watcher": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.0.2.tgz",
+          "integrity": "sha512-uIVJLpQ/5VTGQWBiBatHsi7jrCqHjHl0e0dFHMWzwuIfUbdW/muk0DtSr0fteY2T7QTFylv+7a5Rm8sBKrE12Q==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "emittery": "^0.10.2",
+            "jest-util": "^28.0.2",
+            "string-length": "^4.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
+          "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "pretty-format": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+          "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        },
+        "v8-to-istanbul": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.0.tgz",
+          "integrity": "sha512-HcvgY/xaRm7isYmyx+lFKA4uQmfUbN0J4M0nNItvzTvH/iQ9kW5j/t4YSR+Ge323/lrgDAWJoF46tzGQHwBHFw==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/trace-mapping": "^0.3.7",
+            "@types/istanbul-lib-coverage": "^2.0.1",
+            "convert-source-map": "^1.6.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+          "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        }
+      }
+    },
     "@algolia/autocomplete-core": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz",
@@ -48525,9 +51211,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -49505,6 +52191,334 @@
         "jest-mock": "^27.5.1"
       }
     },
+    "@jest/expect": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.0.2.tgz",
+      "integrity": "sha512-rxgWG/updGoQtHFw/duImu5gPN48+kHvhVjLJ0fFk2mYQ+3dp7/zLiNTjSQxc92Bq4VOk+b6ln0gSgKM4etOtQ==",
+      "dev": true,
+      "requires": {
+        "expect": "^28.0.2",
+        "jest-snapshot": "^28.0.2"
+      },
+      "dependencies": {
+        "@jest/transform": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.0.2.tgz",
+          "integrity": "sha512-PgvB/DEwVY+vJAGTRSFhdmorytx54aXKK1+VQIxVtdFVAe0mJ2fUIRWQuGimveEJWT4ELJImZAIYOgs8z2L0eg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/types": "^28.0.2",
+            "@jridgewell/trace-mapping": "^0.3.7",
+            "babel-plugin-istanbul": "^6.1.1",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.0.2",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "micromatch": "^4.0.4",
+            "pirates": "^4.0.4",
+            "slash": "^3.0.0",
+            "write-file-atomic": "^4.0.1"
+          }
+        },
+        "@jest/types": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+          "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.10",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+          "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz",
+          "integrity": "sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==",
+          "dev": true
+        },
+        "expect": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-28.0.2.tgz",
+          "integrity": "sha512-X0qIuI/zKv98k34tM+uGeOgAC73lhs4vROF9MkPk94C1zujtwv4Cla8SxhWn0G1OwvG9gLLL7RjFBkwGVaZ83w==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "jest-matcher-utils": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-util": "^28.0.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.0.2.tgz",
+          "integrity": "sha512-33Rnf821Y54OAloav0PGNWHlbtEorXpjwchnToyyWbec10X74FOW7hGfvrXLGz7xOe2dz0uo9JVFAHHj/2B5pg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
+          "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.3.2",
+            "graceful-fs": "^4.2.9",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "jest-worker": "^28.0.2",
+            "micromatch": "^4.0.4",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.0.2.tgz",
+          "integrity": "sha512-SxtTiI2qLJHFtOz/bySStCnwCvISAuxQ/grS+74dfTy5AuJw3Sgj9TVUvskcnImTfpzLoMCDJseRaeRrVYbAOA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-message-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz",
+          "integrity": "sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^28.0.2",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^28.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-regex-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+          "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+          "dev": true
+        },
+        "jest-snapshot": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.0.2.tgz",
+          "integrity": "sha512-Y+2red99KRYY5vxA3HIE1p7p2MxPZz5uwamly18DII/9m/D2QQKcYqETS+/DjDthOxpnJWFqqku7MDzdpnHkHg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@babel/generator": "^7.7.2",
+            "@babel/plugin-syntax-typescript": "^7.7.2",
+            "@babel/traverse": "^7.7.2",
+            "@babel/types": "^7.3.3",
+            "@jest/expect-utils": "^28.0.2",
+            "@jest/transform": "^28.0.2",
+            "@jest/types": "^28.0.2",
+            "@types/babel__traverse": "^7.0.6",
+            "@types/prettier": "^2.1.5",
+            "babel-preset-current-node-syntax": "^1.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^28.0.2",
+            "graceful-fs": "^4.2.9",
+            "jest-diff": "^28.0.2",
+            "jest-get-type": "^28.0.2",
+            "jest-haste-map": "^28.0.2",
+            "jest-matcher-utils": "^28.0.2",
+            "jest-message-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^28.0.2",
+            "semver": "^7.3.5"
+          }
+        },
+        "jest-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+          "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "jest-worker": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
+          "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "pretty-format": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+          "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+          "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        }
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.0.2.tgz",
+      "integrity": "sha512-YryfH2zN5c7M8eLtn9oTBRj1sfD+X4cHNXJnTejqCveOS33wADEZUxJ7de5++lRvByNpRpfAnc8zTK7yrUJqgA==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^28.0.2"
+      },
+      "dependencies": {
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        }
+      }
+    },
     "@jest/fake-timers": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
@@ -49886,6 +52900,15 @@
         }
       }
     },
+    "@jest/schemas": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+      "integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.23.3"
+      }
+    },
     "@jest/source-map": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -50262,9 +53285,9 @@
       "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -51627,6 +54650,12 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
+    "@sinclair/typebox": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.4.tgz",
+      "integrity": "sha512-0/WqSvpVbCBAV1yPeko7eAczKbs78dNVAaX14quVlwOb2wxfKuXCx91h4NrEfkYK9zEnyVSW4JVI/trP3iS+Qg==",
+      "dev": true
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -52721,13 +55750,13 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+      "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/type-utils": "5.21.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -52817,47 +55846,47 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+      "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+      "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+      "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
       "requires": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w=="
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+      "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+      "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -52876,24 +55905,24 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+      "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+      "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.21.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -53756,9 +56785,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1115.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1115.0.tgz",
-      "integrity": "sha512-WuMPBkE2b0hGRcF4oYw9zhjG0PC20lFKHT5FS8PXgZgu4GK8adQ8oIK0wBYPjq3F6b+VNdhDWSy3R7a6K+ENOQ==",
+      "version": "2.1124.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1124.0.tgz",
+      "integrity": "sha512-LIj2EmvduQmyjpSLoDPe2TvRBrGWhJKlCuC7lungN4f+qYPOfVWg6/c9GdP99W0q5p2IqhDkCmQ/ZZBpO1Z/Fg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -58178,11 +61207,11 @@
       }
     },
     "eslint": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
-      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
       "requires": {
-        "@eslint/eslintrc": "^1.2.1",
+        "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -63483,32 +66512,50 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.2.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.2.tgz",
-      "integrity": "sha512-tfbHcBs/hJTb3fPQ/3hLWR+TsLNTzzK98TU+zIAsrL9nNzWfWROwopUOmiSUqmHMZW5t9au/433kSF2/Af+tTw==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.0.2.tgz",
+      "integrity": "sha512-4smZQ+Z4bzRNAXmj2HSrDYOAVar/SBDClUWxDJrz3BHbw+URXGAPenziWIShmybBlcRnX0lVCs43UiB7+Fh+lg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
-        "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
-        "escalade": "^3.1.1",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.2.2",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.0.2",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.2.0",
-        "jest-validate": "^27.2.2",
+        "jest-util": "^28.0.2",
+        "jest-validate": "^28.0.2",
         "resolve": "^1.20.0",
+        "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+          "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.10",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+          "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -63518,8 +66565,6 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -63530,8 +66575,6 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -63540,25 +66583,127 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
+          "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.3.2",
+            "graceful-fs": "^4.2.9",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.0.2",
+            "jest-worker": "^28.0.2",
+            "micromatch": "^4.0.4",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-regex-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+          "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+          "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "jest-validate": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.0.2.tgz",
+          "integrity": "sha512-nr0UOvCTtxP0YPdsk01Gk7e7c0xIiEe2nncAe3pj0wBfUvAykTVrMrdeASlAJnlEQCBuwN/GF4hKoCzbkGNCNw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.0.2",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^28.0.2",
+            "leven": "^3.1.0",
+            "pretty-format": "^28.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
+          "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "pretty-format": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+          "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/services/slack/.eslintignore
+++ b/services/slack/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+.build
+dist
+generated
+*.config.*

--- a/services/slack/.eslintrc.json
+++ b/services/slack/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "parserOptions": {
+    "tsconfigRootDir": ".",
+    "project": "./tsconfig(.*)?.json"
+  },
+  "env": {
+    "node": true
+  },
+  "root": true,
+  "rules": {
+    "import/no-import-module-exports": "off",
+    "class-methods-use-this": "off",
+    "consistent-return": "off",
+    "max-classes-per-file": "off",
+    "object-curly-newline": "off",
+    "@typescript-eslint/indent": "off",
+    "no-underscore-dangle": "off",
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "off"
+  },
+  "settings": {
+    "import/resolve": {
+      "typescript": {
+        "alwaysTryType": true,
+        "paths": "./tsconfig.json"
+      },
+      "alias": {
+        "map": [
+          ["@src", "./src"],
+          ["@tests", "./tests"]
+        ],
+        "extensions": [".ts"]
+      }
+    }
+  }
+}

--- a/services/slack/.lintstagedrc.json
+++ b/services/slack/.lintstagedrc.json
@@ -1,0 +1,1 @@
+{ "**/*.{js,ts,tsx}": ["eslint --fix", "prettier --write '**/*.{js,ts,tsx}'"] }

--- a/services/slack/.prettierignore
+++ b/services/slack/.prettierignore
@@ -1,0 +1,17 @@
+# https://github.com/prettier/prettier/issues/4081
+# Must include .prettierignore in each directory that will run prettier
+# Add files here to ignore them from prettier formatting
+dist
+.build
+coverage
+.cache
+.husky
+.next
+.vscode
+package-lock.json
+public
+schema.gql
+generated
+.serverless
+.webpack
+node_modules

--- a/services/slack/babel.config.js
+++ b/services/slack/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+};

--- a/services/slack/package.json
+++ b/services/slack/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@acmutd/slack",
+  "version": "1.0.0",
+  "description": "Handles messaging services between portal and Slack",
+  "main": "handler.js",
+  "scripts": {
+    "test": "NODE_ENV=test ../../node_modules/.bin/jest --ci --verbose",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "buildtest": "tsc --noEmit",
+    "sls:offline": "doppler run -- sls offline"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acmutd/portal-next.git"
+  },
+  "keywords": [
+    "slack"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/acmutd/portal-next/issues"
+  },
+  "homepage": "https://github.com/acmutd/portal-next#readme",
+  "dependencies": {
+    "@middy/core": "^2.5.7",
+    "@middy/http-json-body-parser": "^2.5.7",
+    "@middy/sqs-json-body-parser": "^2.5.7",
+    "@middy/validator": "^2.5.7",
+    "aws-lambda": "^1.0.7",
+    "aws-sdk": "^2.1122.0",
+    "axios": "^0.27.1",
+    "middy-middleware-json-error-handler": "^3.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.17.9",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-typescript": "^7.16.7",
+    "@typescript-eslint/eslint-plugin": "^5.21.0",
+    "@typescript-eslint/parser": "^5.21.0",
+    "babel-jest": "^28.0.1",
+    "eslint": "^8.14.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-import-resolver-typescript": "^2.7.1",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-module-resolver": "^1.4.0",
+    "fork-ts-checker-webpack-plugin": "^7.2.7",
+    "jest": "^28.0.1",
+    "serverless-webpack": "^5.7.0",
+    "typescript-eslint": "^0.0.1-alpha.0",
+    "webpack-node-externals": "^3.0.0"
+  }
+}

--- a/services/slack/serverless.yml
+++ b/services/slack/serverless.yml
@@ -1,0 +1,40 @@
+service: slack
+
+custom:
+  webpack:
+    webpackConfig: webpack.config.js
+    includeModules:
+      forceExclude:
+        - aws-sdk
+    packager: npm
+    packagerOptions:
+      lockFile: '../../package-lock.json'
+  prune:
+    automatic: true
+    number: 3
+
+plugins:
+  - serverless-offline
+  - serverless-webpack
+  - serverless-iam-roles-per-function
+  - serverless-create-global-dynamodb-table
+  - serverless-prune-plugin
+
+provider:
+  name: aws
+  region: us-east-1
+  runtime: nodejs14.x
+  memorySize: 256
+  httpApi:
+    payload: '2.0'
+    cors: true
+
+functions:
+  slack:
+    handler: src/handler.main
+    events:
+      - httpApi:
+          # This is endpoint for function
+          path: /slack
+          # This is HTTP method
+          method: post

--- a/services/slack/src/handler.ts
+++ b/services/slack/src/handler.ts
@@ -1,0 +1,28 @@
+/* eslint @typescript-eslint/no-unsafe-assignment: 0 */
+/* eslint @typescript-eslint/no-unsafe-call: 0 */
+/* eslint @typescript-eslint/no-unsafe-member-access: 0 */
+
+import middy from '@middy/core';
+import jsonBodyParser from '@middy/http-json-body-parser';
+import JSONErrorHandlerMiddleware from 'middy-middleware-json-error-handler';
+import validator from '@middy/validator';
+import { inputSchema } from './schema';
+import type { ValidatedAPIGatewayProxyEvent } from './schema';
+import { sendSlackMessage, SendSlackMessageConfig } from './send-slack-message';
+
+const sendSlackMessageHandler = async (
+  event: ValidatedAPIGatewayProxyEvent<SendSlackMessageConfig>
+) => {
+  const sendSlackMessageStatus = await sendSlackMessage(event.body);
+  return {
+    statusCode: sendSlackMessageStatus ? 200 : 500,
+    body: JSON.stringify({
+      msg: sendSlackMessageStatus ? 'Successfully sent message' : 'Unsuccessfully sent message',
+    }),
+  };
+};
+
+export const main = middy(sendSlackMessageHandler)
+  .use(jsonBodyParser())
+  .use(validator({ inputSchema }))
+  .use(JSONErrorHandlerMiddleware());

--- a/services/slack/src/schema.ts
+++ b/services/slack/src/schema.ts
@@ -1,0 +1,20 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export type ValidatedAPIGatewayProxyEvent<T> = Omit<APIGatewayProxyEvent, 'body'> & { body: T };
+
+export const inputSchema = {
+  type: 'object',
+  properties: {
+    body: {
+      type: 'object',
+      properties: {
+        form_name: { type: 'string' },
+        name: { type: 'string' },
+        email: { type: 'string' },
+        message: { type: 'string' },
+        url: { type: 'string' },
+      },
+      required: ['form_name', 'name', 'email', 'message'],
+    },
+  },
+};

--- a/services/slack/src/send-slack-message.ts
+++ b/services/slack/src/send-slack-message.ts
@@ -1,0 +1,76 @@
+import axios from 'axios';
+
+export interface SendSlackMessageConfig {
+  form_name: string;
+  name: string;
+  email: string;
+  message: string;
+  url?: string;
+}
+
+const fetchChannels = async (): Promise<any> => {
+  const config = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.SLACK_TOKEN!}`,
+    },
+  };
+  return axios.get<any>('https://slack.com/api/conversations.list', config);
+};
+
+export const sendSlackMessage = async (msg: SendSlackMessageConfig): Promise<boolean> => {
+  const channelId = `${process.env.SLACK_WEBHOOK_PROJ_MEMBER_PORTAL!}`;
+  try {
+    const payload = {
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `Thanks for submitting the ${msg.form_name}! Your request has been processed & is now active.`,
+          },
+        },
+        {
+          type: 'divider',
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `${msg.message}`,
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `User: ${msg.name}\nEmail: ${msg.email}`,
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `Resource URL: ${msg.url as string}`,
+          },
+          accessory: {
+            type: 'button',
+            text: {
+              type: 'plain_text',
+              text: 'Visit Page',
+              emoji: true,
+            },
+            value: 'linked_url',
+            url: msg.url,
+            action_id: 'button-action',
+          },
+        },
+      ],
+    };
+    await axios.post(channelId, payload);
+    return true;
+  } catch (error: any) {
+    console.error(JSON.stringify(error));
+    return false;
+  }
+};

--- a/services/slack/tsconfig.json
+++ b/services/slack/tsconfig.json
@@ -1,0 +1,53 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    // project options
+    "lib": ["ES2020"], // specifies which default set of type definitions to use ("DOM", "ES6", etc)
+    "outDir": "lib", // .js (as well as .d.ts, .js.map, etc.) files will be emitted into this directory.,
+    "removeComments": true, // Strips all comments from TypeScript files when converting into JavaScript- you rarely read compiled code so this saves space
+    "target": "ES2020", // Target environment. Most modern browsers support ES6, but you may want to set it to newer or older. (defaults to ES3)
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    // Module resolution
+    "baseUrl": "./", // Lets you set a base directory to resolve non-absolute module names.
+    "esModuleInterop": true, // fixes some issues TS originally had with the ES6 spec where TypeScript treats CommonJS/AMD/UMD modules similar to ES6 module
+    "moduleResolution": "node", // Pretty much always node for modern JS. Other option is "classic"
+    "paths": {
+      "@src/*": ["src/*"],
+      "@tests/*": ["tests/*"]
+    }, // A series of entries which re-map imports to lookup locations relative to the baseUrl
+
+    // Source Map
+    "sourceMap": true, // enables the use of source maps for debuggers and error reporting etc
+    "sourceRoot": "/", // Specify the location where a debugger should locate TypeScript files instead of relative source locations.
+
+    // Strict Checks
+    "alwaysStrict": true, // Ensures that your files are parsed in the ECMAScript strict mode, and emit “use strict” for each source file.
+    "allowUnreachableCode": false, // pick up dead code paths
+    "noImplicitAny": true, // In some cases where no type annotations are present, TypeScript will fall back to a type of any for a variable when it cannot infer the type.
+    "strictNullChecks": true, // When strictNullChecks is true, null and undefined have their own distinct types and you’ll get a type error if you try to use them where a concrete value is expected.
+
+    // Linter Checks
+    // "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true, // accessing index must always check for undefined
+    // "noUnusedLocals": true, // Report errors on unused local variables.
+    // "noUnusedParameters": true, // Report errors on unused parameters in functions
+
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*",
+    "*.config.js"
+  ],
+  "extends": "../../tsconfig.json"
+}

--- a/services/slack/webpack.config.js
+++ b/services/slack/webpack.config.js
@@ -1,0 +1,83 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'eval-cheap-module-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.js', '.json', '.ts'],
+    // symlinks: false,
+    // cacheWithContext: false,
+    alias: {
+      '@src': path.resolve(__dirname, './src'),
+      '@queries': path.resolve(__dirname, './src/queries'),
+      '@tests': path.resolve(__dirname, './tests'),
+      '@generated': path.resolve(__dirname, './generated'),
+    },
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  // experiments: {
+  //   topLevelAwait: true,
+  // },
+  target: 'node',
+  externalsPresets: { node: true },
+  externals: [nodeExternals()],
+  optimization: {
+    minimize: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(tsx?)$/,
+        loader: 'babel-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          presets: [
+            ['@babel/preset-env', { targets: { node: 'current' } }],
+            '@babel/preset-typescript',
+          ],
+          plugins: [
+            'babel-plugin-transform-typescript-metadata',
+            ['@babel/plugin-proposal-decorators', { legacy: true }],
+            ['@babel/plugin-proposal-class-properties', { loose: true }],
+            'babel-plugin-parameter-decorator',
+            ['@babel/plugin-proposal-private-methods', { loose: true }],
+            ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+          ],
+        },
+      },
+      // Need to use babel-loader for babel-plugin-transform-typescript-metadata polyfills which is required by tsyringe
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      // {
+      //   test: /\.(tsx?)$/,
+      //   loader: 'ts-loader',
+      //   exclude: [
+      //     [
+      //       path.resolve(__dirname, 'node_modules'),
+      //       path.resolve(__dirname, '.serverless'),
+      //       path.resolve(__dirname, '.webpack'),
+      //     ],
+      //   ],
+      //   options: {
+      //     transpileOnly: true,
+      //     experimentalWatchApi: true,
+      //   },
+      // },
+    ],
+  },
+  plugins: [new ForkTsCheckerWebpackPlugin()],
+};

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -6,31 +6,35 @@
     },
     {
       "name": "🚀 @acmutd/documentation",
-      "path": "apps/documentation"
+      "path": "apps\\documentation"
     },
     {
       "name": "🚀 @acmutd/email-service",
-      "path": "apps/email-service"
+      "path": "apps\\email-service"
     },
     {
       "name": "🚀 @acmutd/portal",
-      "path": "apps/portal"
+      "path": "apps\\portal"
     },
     {
       "name": "📦 @acmutd/config",
-      "path": "packages/config"
+      "path": "packages\\config"
     },
     {
       "name": "📦 @acmutd/email-helper",
-      "path": "packages/email-helper"
+      "path": "packages\\email-helper"
     },
     {
       "name": "🚀 @acmutd/graphql-lambda",
-      "path": "services/graphql-server"
+      "path": "services\\graphql-server"
     },
     {
       "name": "🚀 @acmutd/sendgrid",
-      "path": "services/sendgrid"
+      "path": "services\\sendgrid"
+    },
+    {
+      "name": "🚀 @acmutd/slack",
+      "path": "services\\slack"
     }
   ],
   "settings": {


### PR DESCRIPTION
### Objective
The Slack lambda function will handle messaging to a Slack channel by means of an *Incoming Webhook*.  The message will bear general information regarding sender information and a message payload. 
#### Current Limitations
The service can only send messages to a specific Slack channel at the time. It's functionality can be tested at `localhost:3000/slack`.
### Next Actions
- [ ] Generalize the function to send messages to a specific Slack channel
  - [ ] Set up Incoming Webhooks for Slack Channels on DynamoDB 
  - [ ] Set up CRUD services for the Incoming Webhooks database collection
- [ ] Document the slack function and all related services
  - Describe the functionality and uses of *Incoming Webhooks* for Slack
  - Describe how to test and debug the service
- [ ] Document the related requests on Postman
- Create templated or general payloads for all message-types