### PR TITLE
feat(toasts): add toasts about email confirmations when creating ap…

### DIFF
--- a/apps/portal/components/EmailToast.tsx
+++ b/apps/portal/components/EmailToast.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '../icons/CloseIcon';
+
+/** A toast is a lightweight notifications designed to mimic the push notifications
+ *  that have been popularized by mobile and desktop operating systems.
+ *
+ * This one is shown to the user to notift them of a confirmation email being sent to them.*/
+export default function EmailToast(openState: {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    openState.setOpen(false);
+  };
+
+  const action = (
+    <React.Fragment>
+      <IconButton color="secondary" size="small" onClick={handleClose}>
+        <CloseIcon />
+      </IconButton>
+    </React.Fragment>
+  );
+
+  return (
+    <div>
+      <Snackbar
+        open={openState.open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+        message="A confirmation has been sent to your email address."
+        action={action}
+      />
+    </div>
+  );
+}

--- a/apps/portal/components/typeformApplicationSystem/update-application-form.tsx
+++ b/apps/portal/components/typeformApplicationSystem/update-application-form.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import ProfileField from '../ProfileField';
 import Router from 'next/router';
 import { TypeformApplication } from '@prisma/client';
+import EmailToast from 'components/EmailToast';
 
 function renderTypeformView(typeformApplication: TypeformApplication): JSX.Element {
   if (!typeformApplication) return <p className="text-gray-100">please select an application</p>;

--- a/apps/portal/icons/CloseIcon.tsx
+++ b/apps/portal/icons/CloseIcon.tsx
@@ -1,0 +1,18 @@
+import { FC, SVGProps } from 'react';
+
+const CloseIcon: FC<SVGProps<SVGSVGElement>> = (props) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 0 24 24"
+      width="24px"
+      fill="#FFFFFF"
+    >
+      <path d="M0 0h24v24H0V0z" fill="none" />
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z" />
+    </svg>
+  );
+};
+
+export default CloseIcon;

--- a/apps/portal/pages/opportunities/create.tsx
+++ b/apps/portal/pages/opportunities/create.tsx
@@ -2,13 +2,8 @@ import { TypeformCreateForm } from 'components/typeformApplicationSystem/update-
 import { NextPage } from 'next';
 import { useForm } from 'react-hook-form';
 import { gql, useMutation } from 'urql';
-import { TypeformApplication } from '@prisma/client';
-import { useState } from 'react';
 import { useRouter } from 'next/router';
-
-import EmailToast from 'components/EmailToast';
 import { useSession } from 'next-auth/react';
-
 
 const CreateApplicationPage: NextPage = () => {
   const router = useRouter();
@@ -44,11 +39,6 @@ const CreateApplicationPage: NextPage = () => {
     handleSubmit,
     formState: { errors },
   } = useForm<FormInputs>();
-
-  const [open, setOpen] = useState(false);
-
-  if (status !== 'authenticated') return <p className="text-gray-100">loading...</p>;
-  
   return (
     <div className="px-16 py-[65px] w-full">
       <header className="flex items-center justify-center relative mb-[30px]">
@@ -68,7 +58,7 @@ const CreateApplicationPage: NextPage = () => {
             className="bg-purple-600 text-gray-100 font-semibold px-12 py-2 rounded-lg"
             form="create-typeform"
             onClick={() => {
-              setOpen(true);
+              sessionStorage.setItem('showToast', '1');
             }}
           >
             save
@@ -79,7 +69,6 @@ const CreateApplicationPage: NextPage = () => {
         </div>
       </div>
       <div className="flex gap-x-16 px-16 justify-center"></div>
-      <EmailToast open={open} setOpen={setOpen}></EmailToast>
     </div>
   );
 };

--- a/apps/portal/pages/opportunities/create.tsx
+++ b/apps/portal/pages/opportunities/create.tsx
@@ -5,6 +5,7 @@ import { gql, useMutation } from 'urql';
 import { TypeformApplication } from '@prisma/client';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import EmailToast from 'components/EmailToast';
 
 const CreateApplicationPage: NextPage = () => {
   const router = useRouter();
@@ -38,6 +39,7 @@ const CreateApplicationPage: NextPage = () => {
     handleSubmit,
     formState: { errors },
   } = useForm<FormInputs>();
+  const [open, setOpen] = useState(false);
   return (
     <div className="px-16 py-[65px] w-full">
       <header className="flex items-center justify-center relative mb-[30px]">
@@ -56,6 +58,9 @@ const CreateApplicationPage: NextPage = () => {
             type="submit"
             className="bg-purple-600 text-gray-100 font-semibold px-12 py-2 rounded-lg"
             form="create-typeform"
+            onClick={() => {
+              setOpen(true);
+            }}
           >
             save
           </button>
@@ -65,6 +70,7 @@ const CreateApplicationPage: NextPage = () => {
         </div>
       </div>
       <div className="flex gap-x-16 px-16 justify-center"></div>
+      <EmailToast open={open} setOpen={setOpen}></EmailToast>
     </div>
   );
 };

--- a/apps/portal/pages/opportunities/index.tsx
+++ b/apps/portal/pages/opportunities/index.tsx
@@ -1,10 +1,12 @@
 import { PopupButton } from '@typeform/embed-react';
 import Button from 'components/Button';
 import CircularBlur from 'components/CircularBlur';
+import EmailToast from 'components/EmailToast';
 import ApplicationCard from 'components/typeformApplicationSystem/ApplicationCard';
 import { NextPage } from 'next';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { gql, useQuery } from 'urql';
 
 interface TypeformApplication {
@@ -53,6 +55,14 @@ const ApplicationsPage: NextPage = () => {
     },
   });
 
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (sessionStorage.getItem('showToast') == '1') {
+      setOpen(true);
+      sessionStorage.removeItem('showToast');
+    }
+  }, []);
+
   if (fetching || status == 'loading') return <p className="text-gray-100">loading...</p>;
   if (error) return <p className="text-gray-100">whoops... {error.message}</p>;
 
@@ -93,6 +103,7 @@ const ApplicationsPage: NextPage = () => {
           ),
         )}
       </div>
+      <EmailToast open={open} setOpen={setOpen}></EmailToast>
     </div>
   );
 };

--- a/apps/portal/pages/profile/index.tsx
+++ b/apps/portal/pages/profile/index.tsx
@@ -16,6 +16,7 @@ import { useSession } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
 import Router from 'next/router';
 import Link from 'next/link';
+import EmailToast from 'components/EmailToast';
 
 export const getServerSideProps = async (ctx) => {
   const { profileVisited } = ctx.req.cookies;
@@ -24,6 +25,7 @@ export const getServerSideProps = async (ctx) => {
 
 export default function ProfilePage({ profileVisited }) {
   const { data: session, status } = useSession({ required: true });
+  const [open, setOpen] = useState(false);
 
   let pageTheme: any = 'dark';
   useEffect(() => {
@@ -112,6 +114,9 @@ export default function ProfilePage({ profileVisited }) {
                 type="submit"
                 className="bg-purple-600 text-gray-100 font-semibold p-2 rounded-lg"
                 form="profile-form"
+                onClick={() => {
+                  setOpen(true);
+                }}
               >
                 save
               </button>
@@ -127,6 +132,7 @@ export default function ProfilePage({ profileVisited }) {
           </Link>
         )}
       </div>
+      <EmailToast open={open} setOpen={setOpen}></EmailToast>
     </>
   );
 


### PR DESCRIPTION
feat(toasts): add toasts about email confirmations when creating applications or profiles

TODO:
- [x] application creation
- [x] profile creation
- [x] event creation

notes: event creation doesnt work the same as the other two because it has a separate page for adding events and redirects away once the form is submitted, which prevents me from creating the toast there. Mike suggested we make a button on the toast which waits for the users click to redirect back instead of doing it automatically. That part is still a WIP.