### PR TITLE
fix(applications): change margin settings to center "Applications" heading

### DIFF
--- a/apps/portal/pages/opportunities/index.tsx
+++ b/apps/portal/pages/opportunities/index.tsx
@@ -80,12 +80,12 @@ const ApplicationsPage: NextPage = () => {
     <div className="px-16 py-[65px] relative">
       <CircularBlur backgroundColor="rgba(129, 53, 218, 1)" top="20%" left="10%" />
       <CircularBlur backgroundColor="#daa635" bottom="20%" right="15%" />
-      <header className="flex items-center justify-center relative mb-[30px]">
-        <h1 className="text-[48px] font-Gilroy text-white font-semibold ml-auto">applications</h1>
+      <header className="flex items-center relative mb-[30px]">
+        <h1 className="text-[48px] font-Gilroy text-white font-semibold mx-auto">applications</h1>
 
         {data.me.isOfficer && (
           <Link href="/opportunities/edit">
-            <Button className="ml-auto">edit</Button>
+            <Button>edit</Button>
           </Link>
         )}
       </header>


### PR DESCRIPTION
`ml-auto` does not effectively center the page heading when only one element is present in the div. `mx-auto` was chosen instead to provide the required margins.

Unnecessary CSS code was removed as well:
- `justify-center`
- `ml-auto`

A slight difference can currently be observed with the non-officer and officer pages, as the non-officer page has slightly larger margins (due to the lack of the edit button). If necessary, this can be fixed with a placeholder div, or ignored.