### PR TITLE
Add director modal

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,7 +177,10 @@ model Division {
     deptName String
 
     officerIds String[]  @db.ObjectId
-    officers   Officer[] @relation(fields: [officerIds], references: [id])
+    officers   Officer[] @relation( fields: [officerIds], references: [id] )
+
+    directorIds String[]   @db.ObjectId
+    directors   Director[] @relation( fields:[directorIds], references:[id] )
 
     applications Application[]
 
@@ -193,8 +196,7 @@ model Officer {
     divisionIds String[]   @db.ObjectId
     divisions   Division[] @relation(fields: [divisionIds], references: [id])
 
-    
-    director Director[]
+    director Director?
 
     @@map("officers")
 }
@@ -203,10 +205,11 @@ model Director {
     id String @id @default(auto()) @map("_id") @db.ObjectId
 
     officerId String @unique @db.ObjectId
-    officer Officer @relation(fields: [officerId], references: [id] )
+    officer Officer? @relation(fields: [officerId], references: [id] )
 
-    dummy String?
-    
+    divisionIds String[] @db.ObjectId
+    divisions   Division[] @relation( fields: [divisionIds], references: [id] )
+
     @@map("directors")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,6 +198,8 @@ model Officer {
 
     @@map("officers")
 }
+// Create new director model - and link them together - play around with it 
+
 
 model Director { 
     id String @id @default(auto()) @map("_id") @db.ObjectId

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -193,7 +193,19 @@ model Officer {
     divisionIds String[]   @db.ObjectId
     divisions   Division[] @relation(fields: [divisionIds], references: [id])
 
+    
+    director Director?
+
     @@map("officers")
+}
+
+model Director { 
+    id String @id @default(auto()) @map("_id") @db.ObjectId
+
+    officerId String @unique @db.ObjectId
+    officer Officer @relation(fields: [officerId], references: [id] )
+
+    @@map("directors")
 }
 
 // if explicit m-to-n relations are needed:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,12 +194,10 @@ model Officer {
     divisions   Division[] @relation(fields: [divisionIds], references: [id])
 
     
-    director Director?
+    director Director[]
 
     @@map("officers")
 }
-// Create new director model - and link them together - play around with it 
-
 
 model Director { 
     id String @id @default(auto()) @map("_id") @db.ObjectId
@@ -207,6 +205,8 @@ model Director {
     officerId String @unique @db.ObjectId
     officer Officer @relation(fields: [officerId], references: [id] )
 
+    dummy String?
+    
     @@map("directors")
 }
 


### PR DESCRIPTION
Add Director Modal. Currently Director modal inherits from the officers modal because every director is an officer but not all officers is a director. Ran into issue of DirectorUpdateWithoutOfficeInput - pretty much director has 2 fields, and since officerID is not a real field in the database, it has object without field and throw a typegraphql error. Could not find a way to turn off that typegraphql, so a fix is to be an optional Officer field. 