### PR TITLE
Check if director

### DIFF
--- a/lib/graphql/resolvers/users.resolver.ts
+++ b/lib/graphql/resolvers/users.resolver.ts
@@ -27,7 +27,7 @@ export default class AdditionalUserResolver {
 
   @FieldResolver( () => Boolean) 
   async isDirector(@Root() user: User): Promise<boolean> {
-    return this.userService.checkIfOfficerIsDirector(user.id);
+    return this.userService.checkIfUserIsDirector(user.id);
   }
 
   @FieldResolver(() => [Event])

--- a/lib/graphql/resolvers/users.resolver.ts
+++ b/lib/graphql/resolvers/users.resolver.ts
@@ -25,6 +25,11 @@ export default class AdditionalUserResolver {
     return this.userService.checkIfUserIsOfficer(user.id);
   }
 
+  @FieldResolver( () => Boolean) 
+  async isDirector(@Root() user: User): Promise<boolean> {
+    return this.userService.checkIfOfficerIsDirector(user.id);
+  }
+
   @FieldResolver(() => [Event])
   async attendedEvents(@Root() user: User): Promise<Event[]> {
     return this.userService.getAttendedEventsByUserId(user.id);

--- a/lib/graphql/services/users.service.ts
+++ b/lib/graphql/services/users.service.ts
@@ -33,7 +33,7 @@ export default class AdditionalUserService {
     return !!officer;
   }
 
-  async checkIfOfficerIsDirector(userId: string ) : Promise<boolean> {
+  async checkIfUserIsDirector(userId: string ) : Promise<boolean> {
     const profile = await this.prismaConnection.profile.findFirst({
       where: {
         userId

--- a/lib/graphql/services/users.service.ts
+++ b/lib/graphql/services/users.service.ts
@@ -33,6 +33,29 @@ export default class AdditionalUserService {
     return !!officer;
   }
 
+  async checkIfOfficerIsDirector(userId: string ) : Promise<boolean> {
+    const profile = await this.prismaConnection.profile.findFirst({
+      where: {
+        userId
+      }
+    });
+    if (!profile) return false;
+
+    const officer = await this.prismaConnection.officer.findFirst({
+      where: {
+        profileId : profile.id
+      }
+    });
+    if (!officer) return false;
+
+    const director = await this.prismaConnection.director.findFirst({
+      where: {
+        officerId: officer.id
+      }
+    })
+
+    return !!director; 
+  }
   async getAttendedEventsByUserId(userId: string): Promise<Event[]> {
     const profile = await this.prismaConnection.profile.findFirst({
       where: {


### PR DESCRIPTION
Add a check to check if a user is a director. Logic: Grab profile of the user, grab the officer id, and compare that officer id to the director id. If director id and officer id match, then return true. After testing and adding a dummy director data to Mike, the check returned true for only Mike.  As shown in the picture below.

![image](https://github.com/acmutd/portal-next/assets/90099089/f8e4b256-64ac-4471-a017-20a39030df47)