### PR TITLE
Improved admin dashboard

### DIFF
--- a/pages/admin/events/stats.tsx
+++ b/pages/admin/events/stats.tsx
@@ -81,7 +81,9 @@ export default function EventStatsPage() {
         <div className="col-start-1 row-start-1 row-span-7 col-span-1">
           <EventListView
             onChangeSearchQuery={debounceSearchQuery}
-            events={filteredEvents}
+            events={filteredEvents.sort(
+              (a, b) => new Date(b.start).getTime() - new Date(a.start).getTime(),
+            )}
             onEventClick={(e) => setCurrentEvent(e)}
           />
         </div>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -5,34 +5,47 @@ import { OfficerStatusContext } from 'components/context/OfficerStatus';
 import { useContext } from 'react';
 import AdminOnlyComponent from 'components/admin/AdminOnly';
 
+interface AdminFunctionalityOptionType {
+  title: string;
+  description: string;
+  onChosen: () => void;
+  directorOnly: boolean;
+  // flag is true if functionality is reserved for either ACM executive or Development Director only
+  devDirectorOrExecOnly: boolean;
+}
+
 export default function AdminToolsPage() {
   useSession({ required: true });
   const router = useRouter();
   const officerStatusData = useContext(OfficerStatusContext);
-  const options = [
+  const options: AdminFunctionalityOptionType[] = [
     {
       title: 'Create Vanity Link',
       description: 'Click here to start creating your Vanity URL with ACM domain.',
       onChosen: () => router.push('/admin/vanity'),
       directorOnly: false,
+      devDirectorOrExecOnly: false,
     },
     {
       title: 'View events statistics',
       description: 'Click here to view participation metrics of ACM events.',
       onChosen: () => router.push('/admin/events/stats'),
       directorOnly: true,
+      devDirectorOrExecOnly: false,
     },
     {
       title: 'Add officer to division',
       description: 'Add new officer into division.',
       onChosen: () => router.push('/admin/officer/add'),
       directorOnly: true,
+      devDirectorOrExecOnly: false,
     },
     {
       title: 'Manage Membership Status',
       description: 'Click here to manage membership of ACM Portal users',
       onChosen: () => router.push('/admin/member/manage'),
       directorOnly: true,
+      devDirectorOrExecOnly: true,
     },
     // {
     //   title: 'Create Division Application',
@@ -45,26 +58,36 @@ export default function AdminToolsPage() {
       description: 'Manage Director',
       onChosen: () => router.push('/admin/director/manage'),
       directorOnly: true,
+      devDirectorOrExecOnly: true,
     },
     {
       title: 'Manage Typeform Application',
       description: 'Click here to manage all Typeform application',
       onChosen: () => router.push('/admin/typeform/'),
       directorOnly: true,
+      devDirectorOrExecOnly: false,
     },
     {
       title: 'Add Event',
       description: 'Click here to create an event for your division(s)',
       onChosen: () => router.push('/admin/events/add'),
       directorOnly: false,
+      devDirectorOrExecOnly: false,
     },
     {
       title: 'Edit Events',
       description: 'Click here to edit recent event data',
       onChosen: () => router.push('/admin/events/edit'),
       directorOnly: false,
+      devDirectorOrExecOnly: false,
     },
   ];
+  const isDevDirectorOrExec = () => {
+    return (
+      officerStatusData.directorOfDivisions.includes('Development') ||
+      officerStatusData.directorOfDivisions.includes('Executive')
+    );
+  };
   if (!officerStatusData.isOfficer) {
     return <AdminOnlyComponent />;
   }
@@ -74,6 +97,9 @@ export default function AdminToolsPage() {
       <div className="flex flex-col gap-y-6 w-full">
         {options
           .filter(({ directorOnly }) => (officerStatusData.isDirector ? true : !directorOnly))
+          .filter(({ devDirectorOrExecOnly }) =>
+            isDevDirectorOrExec() ? true : !devDirectorOrExecOnly,
+          )
           .map(({ title, description, onChosen }, idx) => (
             <div
               key={idx}


### PR DESCRIPTION
Changes made in this PR: 
- Sort events by date in reverse order in `/admin/events/stats`
- Hide reserved functionalities in admin dashboard based on user's permissions.  