### PR TITLE
added case-insensitive matching for net ID in admin participant add page

### DIFF
--- a/pages/admin/participant/add.tsx
+++ b/pages/admin/participant/add.tsx
@@ -37,7 +37,7 @@ export default function AddParticipant() {
       setFilteredProfiles(
         (data?.profiles || []).filter(
           (profile) =>
-            profile.netid === searchQuery ||
+            profile.netid.toLowerCase() === searchQuery.toLowerCase() ||
             `${profile.firstName} ${profile.lastName}`.toLowerCase() ===
               searchQuery.toLowerCase() ||
             profile.firstName.toLowerCase() === searchQuery.toLowerCase() ||


### PR DESCRIPTION
Searching by net ID for admins in the participant add page is case-sensitive. I made it case-insensitive.