### PR TITLE
fix: Fixed visual bug on class standing dropdown

### DIFF
--- a/components/profile/ProfileEditView.tsx
+++ b/components/profile/ProfileEditView.tsx
@@ -110,11 +110,11 @@ export default function ProfileEditView({ profile, onUpdateFormCompleted, onErro
             <div className="w-full px-3">
               <label className="block text-gray-200 font-semibold mb-2">class standing</label>
               <select
-                className="appearance-none block w-full text-black hover:text-gray-100 rounded py-3 px-4 mb-3 leading-tight focus:outline-none bg-transparent border border-gray-600"
+                className="appearance-none block w-full text-white rounded py-3 px-4 mb-3 leading-tight focus:outline-none bg-transparent border border-gray-600"
                 {...register('classStanding')}
               >
                 {["freshman", "sophomore", "junior", "senior", "graduate"].map((standing) => (
-                  <option value={standing}>{standing}</option>
+                  <option className="text-black hover:text-gray-100" value={standing}>{standing}</option>
                 ))}
               </select>
             </div>

--- a/components/profile/ProfileEditView.tsx
+++ b/components/profile/ProfileEditView.tsx
@@ -110,7 +110,7 @@ export default function ProfileEditView({ profile, onUpdateFormCompleted, onErro
             <div className="w-full px-3">
               <label className="block text-gray-200 font-semibold mb-2">class standing</label>
               <select
-                className="appearance-none block w-full text-gray-100 rounded py-3 px-4 mb-3 leading-tight focus:outline-none bg-transparent border border-gray-600"
+                className="appearance-none block w-full text-black hover:text-gray-100 rounded py-3 px-4 mb-3 leading-tight focus:outline-none bg-transparent border border-gray-600"
                 {...register('classStanding')}
               >
                 {["freshman", "sophomore", "junior", "senior", "graduate"].map((standing) => (


### PR DESCRIPTION
The class standing dropdown in the profile edit menu has a visual bug where the option text color blends in with the dropdown background.
![image](https://github.com/user-attachments/assets/ec788f48-0592-4dd1-b9c8-3d7f923a05ee)

To fix this, simply make the default color of the option text black, and change the color to the original color (`text-gray-100`) when hovered.