### PR TITLE
adding finance and an option for no org unit

### DIFF
--- a/pages/admin/officer-onboarding.tsx
+++ b/pages/admin/officer-onboarding.tsx
@@ -3,7 +3,8 @@ import { useSession } from 'next-auth/react';
 import { motion } from 'framer-motion';
 import { TrashIcon } from '@radix-ui/react-icons'; // import trashcan icon
 
-const orgUnits = ['/Development', '/Education', '/Research', '/HackUTD', '/Projects', '/Industry', '/Media', '/Community'];
+// org units and groups from google admin
+const orgUnits = ['/Development', '/Education', '/Research', '/HackUTD', '/Projects', '/Industry', '/Media', '/Community', '/Finance', 'N/A'];
 const groups = [
   'acmindustry@acmutd.co',
   'community@acmutd.co',


### PR DESCRIPTION
- Created the Finance Organization Unit in Google Admin for Finance Officers to use the onboarding script
- Created a "N/A" option in the script dropdown to reduce future revisions if a division without an org unit is added
- Upgraded the project build in Vercel from Node 18x to Node 22x